### PR TITLE
Fix #63

### DIFF
--- a/weather10kb.js
+++ b/weather10kb.js
@@ -109,10 +109,9 @@ function Weather10kbRequest(request) {
 
 router.get('/:location?/:scale?', function(request, response) {
   // validate
-  (function() {
     // check for & handle a querystring variable in case the user submitted the location form rather than passing a url param
     if (typeof request.query.location === 'string') {
-      response.redirect('/' + request.query.location);
+      return response.redirect('/' + request.query.location);
     }
 
     // if we got a scale and not a location for the first param, adjust params accordingly
@@ -128,7 +127,6 @@ router.get('/:location?/:scale?', function(request, response) {
     }
 
     request.params.units = (typeof request.params.scale === 'string' && request.params.scale === 'C') ? 'si' : 'us'
-  })();
 
   var wr = new Weather10kbRequest(request);
 
@@ -147,7 +145,7 @@ router.get('/:location?/:scale?', function(request, response) {
         throw 'Undetermined location.';
       }
 
-      response.render('pages/index', objectMerge(data, {params: request.params}));
+      return response.render('pages/index', objectMerge(data, {params: request.params}));
     })
     .catch(function(err){
       if (err instanceof Error) {
@@ -156,7 +154,7 @@ router.get('/:location?/:scale?', function(request, response) {
         var err_msg = JSON.stringify(err);
       }
 
-      response.render('pages/error', {error: err_msg});
+      return response.render('pages/error', {error: err_msg});
     });
 });
 


### PR DESCRIPTION
My understanding of #63:
1. City is submitted through input box. Validation function fires a redirect, thus executing route code for a second time.
2. Original entry point attempts to execute remaining route code (generating an error in the process). New route skips validation, renders page.

To fix, I removed the function that wrapped the validation code and added return statements. Now when the validation function fires a redirect, it exits the code (preventing the error). The route then loads again (correctly) because of the redirect. I think better flow control should be implemented here, but it worked in my brief tests.
