### PR TITLE
Removing conditional statement that was hiding partials/daily with we

### DIFF
--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -47,14 +47,11 @@
           </div>
         </header>
         <%
-        var currentTime = moment.unix(currently.time);
-        var tomorrowTime = currentTime.clone().add(1, 'days').startOf('day');
-        var showTomorrow = currentTime.diff(tomorrowTime.clone().subtract(6, 'hours')) >= 0;
+          var currentTime = moment.unix(currently.time);
+          var tomorrowTime = currentTime.clone().add(1, 'days').startOf('day');
         %>
         <%- include('../partials/daily', {data: {name: "Today", daily: daily.data[0], hourly: hourly.data, tomorrowTime: tomorrowTime}})%>
-        <% if(showTomorrow) { %>
-            <%- include('../partials/daily', {data: {name: "Tomorrow", daily: daily.data[1], hourly: hourly.data, tomorrowTime: tomorrowTime}})%>
-        <% } %>
+        <%- include('../partials/daily', {data: {name: "Tomorrow", daily: daily.data[1], hourly: hourly.data, tomorrowTime: tomorrowTime}})%>
         <section class="card">
           <h3 class="small muted">This week</h3>
           <p class="forecast-primary">


### PR DESCRIPTION
Removed the `showTomorrow` value and associated conditional statement from `index.ejs` in order to always show tomorrow's weather, regardless of what time it is.

Note: It might be possible to make rendering the partials/daily view for tomorrow's weather slightly more efficient by adding a check before displaying `forecast-secondary` content so as to not even check it tomorrow is more than 6 hours away, but that might be overkill.