### PR TITLE
Collapsing hourly weather reports if temp is same

### DIFF
--- a/views/partials/daily.ejs
+++ b/views/partials/daily.ejs
@@ -25,15 +25,18 @@
     <%
     for (var i = 1; i < 12; i++) {
         var hourlyTime = moment.unix(data.hourly[i].time);
+        var nextHourlyTime = moment.unix(data.hourly[i + 1].time);
         if(hourlyTime.diff(data.tomorrowTime) < 0 && data.name == "Tomorrow") { // Is today but showing Tomorrow
             continue;
         }
         if(hourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today") { // Is tomorrow but showing Today
             break;
         }
-        // If temperature is the same as next hour AND we aren't on the last hour of Today,
-        // add the current hour startime to the next hour and skip this hour.
-        if(!(moment.unix(data.hourly[i + 1].time).diff(data.tomorrowTime) >= 0 && data.name == "Today")
+        // If it's not the last hour of the "Today" report AND it's not the last hour of the "Tomorrow"
+        // report AND the current hour's temperature is the same as next hour's temperature, then add
+        // the current hour startime to the next hour and don't display this hour
+        if(!(nextHourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today")
+          && !(nextHourlyTime.diff(data.tomorrowTime) < 0 && data.name == "Tomorrow")
           && Math.round(data.hourly[i].temperature) === Math.round(data.hourly[i + 1].temperature)
         ) {
           data.hourly[i + 1].startTime = data.hourly[i].startTime || data.hourly[i].time;

--- a/views/partials/daily.ejs
+++ b/views/partials/daily.ejs
@@ -31,9 +31,19 @@
         if(hourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today") { // Is tomorrow but showing Today
             break;
         }
+        // If temperature is the same as next hour AND we aren't on the last hour of Today,
+        // add the current hour startime to the next hour and skip this hour.
+        if(!(moment.unix(data.hourly[i + 1].time).diff(data.tomorrowTime) >= 0 && data.name == "Today")
+          && Math.round(data.hourly[i].temperature) === Math.round(data.hourly[i + 1].temperature)
+        ) {
+          data.hourly[i + 1].startTime = data.hourly[i].startTime || data.hourly[i].time;
+          continue;
+        }
     %>
     <li>
-      <span class="small muted data-secondary"><%= hourlyTime.format(params.hoursFormat + (params.hoursFormat === 'H' ? ':mm' : ''))%><% if (params.hoursFormat === 'h') { %><span class="small-caps"><%= hourlyTime.format('a') %></span><% } %></span>
+      <span class="small muted data-secondary">
+        <%= data.hourly[i].startTime ? moment.unix(data.hourly[i].startTime).format(params.hoursFormat + (params.hoursFormat === 'H' ? ':mm' : '')) + '-' : '' %><%= hourlyTime.format(params.hoursFormat + (params.hoursFormat === 'H' ? ':mm' : ''))%><% if (params.hoursFormat === 'h') { %><span class="small-caps"><%= hourlyTime.format('a') %></span><% } %>
+      </span>
       <span class="m-x-1"><%= Math.round(data.hourly[i].temperature) %>º</span>
       <span><%- include('../partials/summary', {data: data.hourly[i]}) %></span>
     </li>


### PR DESCRIPTION
This resolves [issue 125](https://github.com/JulianNorton/weather-10kb/issues/125), but the math used to determine if two hours are identical is not fully defined. Currently it only compares the rounded temperature:

That logic can be expanded by modifying the conditional on on line 40 of views/partials/daily.ejs:
`Math.round(data.hourly[i].temperature) === Math.round(data.hourly[i + 1].temperature`

Let me know what the ideal behavior is and I'll make the update to this PR.