### PR TITLE
Merging hours by summary instead of by temperature

### DIFF
--- a/views/partials/daily.ejs
+++ b/views/partials/daily.ejs
@@ -32,12 +32,17 @@
         if(hourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today") { // Is tomorrow but showing Today
             break;
         }
+
+        // Calcualte current and next hourly summary strings to determine if the hours should be collapsed
+        var hourlySummary = include('../partials/summary', {data: data.hourly[i]})
+        var nextHourlySummary = include('../partials/summary', {data: data.hourly[i + 1]})
+
         // If it's not the last hour of the "Today" report AND it's not the last hour of the "Tomorrow"
         // report AND the current hour's temperature is the same as next hour's temperature, then add
         // the current hour startime to the next hour and don't display this hour
         if(!(nextHourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today")
           && !(nextHourlyTime.diff(data.tomorrowTime) < 0 && data.name == "Tomorrow")
-          && Math.round(data.hourly[i].temperature) === Math.round(data.hourly[i + 1].temperature)
+          && hourlySummary === nextHourlySummary
         ) {
           data.hourly[i + 1].startTime = data.hourly[i].startTime || data.hourly[i].time;
           continue;
@@ -48,7 +53,7 @@
         <%= data.hourly[i].startTime ? moment.unix(data.hourly[i].startTime).format(params.hoursFormat + (params.hoursFormat === 'H' ? ':mm' : '')) + '-' : '' %><%= hourlyTime.format(params.hoursFormat + (params.hoursFormat === 'H' ? ':mm' : ''))%><% if (params.hoursFormat === 'h') { %><span class="small-caps"><%= hourlyTime.format('a') %></span><% } %>
       </span>
       <span class="m-x-1"><%= Math.round(data.hourly[i].temperature) %>º</span>
-      <span><%- include('../partials/summary', {data: data.hourly[i]}) %></span>
+      <span><%- hourlySummary %></span>
     </li>
     <% } %>
   </ul>

--- a/views/partials/daily.ejs
+++ b/views/partials/daily.ejs
@@ -26,6 +26,7 @@
     for (var i = 1; i < 12; i++) {
         var hourlyTime = moment.unix(data.hourly[i].time);
         var nextHourlyTime = moment.unix(data.hourly[i + 1].time);
+
         if(hourlyTime.diff(data.tomorrowTime) < 0 && data.name == "Tomorrow") { // Is today but showing Tomorrow
             continue;
         }
@@ -33,12 +34,12 @@
             break;
         }
 
-        // Calcualte current and next hourly summary strings to determine if the hours should be collapsed
+        // Calculate current and next hourly summary strings to determine if the hours should be collapsed
         var hourlySummary = include('../partials/summary', {data: data.hourly[i]})
         var nextHourlySummary = include('../partials/summary', {data: data.hourly[i + 1]})
 
         // If it's not the last hour of the "Today" report AND it's not the last hour of the "Tomorrow"
-        // report AND the current hour's temperature is the same as next hour's temperature, then add
+        // report AND the current hour's summary text is the same as next hour's summary text, then add
         // the current hour startime to the next hour and don't display this hour
         if(!(nextHourlyTime.diff(data.tomorrowTime) >= 0 && data.name == "Today")
           && !(nextHourlyTime.diff(data.tomorrowTime) < 0 && data.name == "Tomorrow")


### PR DESCRIPTION
With this change the app will calculating the current hour summary and the next hour summary (ie. "Partly cloudy with a 3 m/s breeze") and compare them. If they are identical the hour will be skipped and included in an hourly summary (ie. "2-4 PM Partly cloudy with a 3 m/s breeze").

In this case, since we're not comparing by temperature, only the temperature of the LAST hour in the summary will be shown.