### PR TITLE
Add timezone tests

### DIFF
--- a/src/modules/WeatherRequest.js
+++ b/src/modules/WeatherRequest.js
@@ -76,11 +76,10 @@ function WeatherRequest(req) {
   };
 
   this.setTimeZone = () => {
-    timezone({ location: req.params.latitude + ',' + req.params.longitude })
+    return timezone({ location: req.params.latitude + ',' + req.params.longitude })
       .then(res => {
         req.params.tz = res.timeZoneId;
         moment.tz.setDefault(req.params.tz);
-        return res;
       });
   };
 

--- a/src/routerHelper.js
+++ b/src/routerHelper.js
@@ -3,14 +3,9 @@
 const { defaultUnits } = require('./config.json');
 
 
-function getPrevCookie(req, name) {
+exports.getPrevCookie = (req, name) => {
   const cookie = req.cookies[name];
   if (cookie && typeof cookie === 'object' && 'units' in cookie && cookie.units in defaultUnits) {
     return cookie;
   }
-}
-
-
-module.exports = {
-  getPrevCookie: getPrevCookie
 };

--- a/test/integration/forecast.test.js
+++ b/test/integration/forecast.test.js
@@ -3,12 +3,11 @@
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const expect = chai.expect;
+const moment = require('moment-timezone');
+const app = require('../../src/app');
 
 
 chai.use(chaiHttp);
-
-const app = require('../../src/app');
-
 
 describe('Forecast location', () => {
 
@@ -34,13 +33,38 @@ describe('Forecast location', () => {
   });
 
   it('should display default units based on location', () => {
-    return chai.request.agent(app)
+    return chai.request.agent(app)  // agent retains cookies
       .get('/New%20York')
       .then(res => {
         expect(res).to.have.status(200);
         expect(res.text).to.contain('Fahrenheit, imperial (current)');
         expect(res.text).to.match(/[0-9]{1,3}°F/);
         expect(res.text).to.match(/[0-9].+?\smph/);
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  // NOTE: must do this before the following test in case location defaults to Los Angeles
+  it('should set the initial timezone for a location', () => {
+    return chai.request(app)
+      .get('/New%20York')
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(moment().tz()).to.equal('America/New_York');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  it('should set the correct timezone for a location', () => {
+    return chai.request(app)
+      .get('/Los%20Angeles')
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(moment().tz()).to.equal('America/Los_Angeles');
       })
       .catch(err => {
         throw err;
@@ -120,8 +144,7 @@ describe('Forecast units', () => {
 
   unitsTestCases.forEach(testCase => {
     it(testCase.describe, () => {
-      // Using agent to persist the cookie during redirect
-      return chai.request.agent(app)
+      return chai.request.agent(app)  // agent retains cookies
         .get(`/New%20York?units=${testCase.setting}`)
         .then(res => {
           expect(res).to.have.status(200);


### PR DESCRIPTION
Added timezone integration tests and fixed promise chaining to allow `setTimeZone` to propagate errors.