### PR TITLE
Make CircleCi mocha results useful.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - .node_modules
+
+      - run:
+          name: tests
+          command: 'npx nyc mocha'
+
       - run:
           name: test
           command: './node_modules/.bin/nyc -r html --report-dir reports/coverage/html ./node_modules/.bin/mocha --reporter=xunit --reporter-options output=reports/test-results.xml'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,14 @@ jobs:
             - .node_modules
 
       - run:
-          name: tests
+          name: run-tests
           command: 'npx nyc mocha'
 
       - run:
-          name: test
+          name: test-reporter
           command: './node_modules/.bin/nyc -r html --report-dir reports/coverage/html ./node_modules/.bin/mocha --reporter=xunit --reporter-options output=reports/test-results.xml'
       - run:
-          name: coverage
+          name: generate-coverage
           command: './node_modules/.bin/nyc report --reporter=text-lcov > reports/coverage/coverage.lcov'
       - store_test_results:
           path: reports/test-results.xml


### PR DESCRIPTION
# Purpose
In response to issue #158.

# What does this do
Keep in mind i have never touched nyc, or mocha, but i am familiar with other test runners.
I am also fairly familiar with CircleCI as i use that on a regular basis at work.

All i have done in this PR is run mocha through nyc, the normal way it should work is that if all the test pass, it should exit successfully, if any fail, it should exit with an error code and prevent the build from completing.


## Some background info
`npx` was added in `npm 5` as a tool that can directly run node modules, which means you don't need to call `./node_modules/.run/mocha` and instead can just do `npx mocha`
You will see an example of this in `.circleci/config.yml`

Couple of recommendations: 
- avoid inline command arguments. Instead use config files that the packages you use expect.
- your (now named `test-reporter`) step seems to be swallowing any errors through the reporter. It would possibly be best to turn this into 1 step that both outputs a human-readable report to the console on which tests passed/failed, and generate code coverage for use with third party tools like coveralls (or however you prefer to view your code coverage 😉 )

I can do some research into how to do these. As far as fixing failing tests, hopefully this is enough to get you started.

Let me know, I'm happy to work on this with you.

https://circleci.com/gh/AlexSwensen/weather-10kb/2