### PR TITLE
Implement security headers with helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-minify-html": "0.6.0",
     "geoip-lite": "1.1.8",
     "google-timezone-api": "1.0.1",
+    "helmet": "^3.8.2",
     "moment-timezone": "0.5.5",
     "node-freegeoip": "0.0.1",
     "node-geocoder": "3.14.0",

--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,7 @@ app.locals.moment = moment;
 app.use(compression());
 app.use(helmet({
   referrerPolicy: {
-    policy: 'strict-origin-when-cross-origin'
+    policy: "strict-origin-when-cross-origin"
   },
   contentSecurityPolicy: {
     directives: {

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ const cookieParser = require('cookie-parser');
 const moment = require('moment-timezone');
 const minifyHTML = require('express-minify-html');
 const router = require('./router');
+const helmet = require('helmet');
 
 
 const app = new express();
@@ -21,6 +22,7 @@ app.get('/.well-known/acme-challenge/:content', (req, res) => {
 app.locals.moment = moment;
 
 app.use(compression());
+app.use(helmet()); // TODO add more headers
 app.use(minifyHTML({
   override: true,
   htmlMinifier: {

--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@ const cookieParser = require('cookie-parser');
 const moment = require('moment-timezone');
 const minifyHTML = require('express-minify-html');
 const router = require('./router');
-const helmet = require('helmet');
+const helmet = require("helmet");
 
 
 const app = new express();

--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,18 @@ app.get('/.well-known/acme-challenge/:content', (req, res) => {
 app.locals.moment = moment;
 
 app.use(compression());
-app.use(helmet()); // TODO add more headers
+app.use(helmet({
+  referrerPolicy: {
+    policy: 'strict-origin-when-cross-origin'
+  },
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"]
+      // unsafe-inline because there is a <style> in <head>
+    }
+  }
+}));
 app.use(minifyHTML({
   override: true,
   htmlMinifier: {


### PR DESCRIPTION
Fixes #161 

As long as there is a `<style>...</style>` in the page,  the content security policy has to include `styleSrc: 'unsafe-inline'`