### PR TITLE
Fixes #190: Use var instead of let in strict mode.

### DIFF
--- a/public/sw-registration.js
+++ b/public/sw-registration.js
@@ -11,7 +11,7 @@ function registerServiceWorker() {
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.getRegistrations().then(function(registrations) {
-    for(let registration of registrations) {
+    for(var registration of registrations) {
       registration.unregister();
     }
     window.addEventListener('load', registerServiceWorker);


### PR DESCRIPTION
Fixes #190 . This PR resolves `Uncaught SyntaxError` by using `var` instead of `let` under _strict_ mode.