### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.circleci
+node_modules
+mockups
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Setup base image, using latest Node on Alpine Linux
+FROM node:alpine as base
+WORKDIR /weather-10kb
+
+# Inclue build dependencies as a seperate stage, so they are excluded from the
+# final image
+FROM base as build
+RUN apk --no-cache add build-base python-dev
+COPY package.json .
+COPY package-lock.json .
+RUN yarn install --frozen-lockfile
+COPY public public
+RUN npm run build-css
+
+# Release
+FROM base as release
+COPY . .
+COPY --from=build /weather-10kb/public .
+RUN yarn install --production --frozen-lockfile
+
+EXPOSE 5000
+CMD ["node", "index.js"]


### PR DESCRIPTION
This adds a Dockerfile, so the application can now be built and run through Docker. I added this because I want to run it on my Raspberry Pi, but don't like having it littered with all sorts of deps, so like to run things through Docker.

The [running it locally](https://github.com/JulianNorton/weather-10kb/wiki/%E2%AD%90-Set-up-the-Weather-10kb-environment) instructions can be reduced to:

1) Clone the repository `git clone https://github.com/JulianNorton/weather-10kb.git`
2) Build the docker image: `docker build -t weather-10kb .`
3) Run the application `docker run --rm -e DARK_SKY_API_KEY=<key> -e GOOGLE_API_KEY=<key> -p 5000:5000 weather-10kb`

Or you could even [push this to the Docker Hub](https://docs.docker.com/docker-hub/builds/), and shorten it to one line :)